### PR TITLE
modify $qs to v0/search

### DIFF
--- a/v0/search/index.php
+++ b/v0/search/index.php
@@ -7,9 +7,20 @@ $core = 'jobs';
 $qs = '?';
 $qs = $qs . $_SERVER['QUERY_STRING'];
 
-if ( $_SERVER['QUERY_STRING'] == "page=1") {$qs .= "&q=*%3A*";} 
-$url = 'http://' . $server . '/solr/' . $core . '/select' . $qs;
+if ($_SERVER['QUERY_STRING'] == "page=1") {
+    $qs .= "&q=%22*%3A*%22"; // Enclose the search query in quotes
+} else {
+    // Ensure other queries are also enclosed in quotes
+    parse_str($_SERVER['QUERY_STRING'], $queryParams);
+    if (isset($queryParams['q'])) {
+        // Construct the query string in the required format
+        $query = $queryParams['q'];
+        $queryParams['q'] = '"' . $query . '"';
+        $qs = '?' . http_build_query($queryParams);
+    }
+}
 
+$url = 'http://' . $server . '/solr/' . $core . '/select' . $qs;
 
 $json = file_get_contents($url);
 echo $json;


### PR DESCRIPTION
Now, in swagger-ui when you try to search a job my its name or company, you only have to write it and the jobs are right. It is sent between "".
e.g. `Technical Trainer` is sent as `"Technical Trainer"`
closes #298 