### PR TITLE
Removed "empty value" in v0/cleanjobs

### DIFF
--- a/v0/swagger.json
+++ b/v0/swagger.json
@@ -243,6 +243,7 @@
             "application/x-www-form-urlencoded": {
               "schema": {
                 "type": "object",
+                "required": [ "company" ],
                 "properties": {
                   "company": {
                     "type": "string",


### PR DESCRIPTION
No need for the "empty value" checkbox in v0/cleanjobs

Closes #436