### PR TITLE
Removed the "--" option in  v0/companies

### DIFF
--- a/v0/swagger.json
+++ b/v0/swagger.json
@@ -329,9 +329,11 @@
             "in": "query",
             "name": "count",
             "schema": {
-              "type": "boolean"
+              "type": "boolean",
+              "enum": [ true, false ]
             },
-            "description": "Whether to count the number of jobs for each company"
+            "description": "Whether to count the number of jobs for each company",
+            "required": true
           }
         ],
         "responses": {


### PR DESCRIPTION
Rather than showing an error when '--' was selected,  I opted to remove the option altogether. 
Closes #437