### PR TITLE
Add Fallback Implementation for Solr Endpoint

### DIFF
--- a/v3/config.php
+++ b/v3/config.php
@@ -2,6 +2,7 @@
 
 //main server
 $server = 'zimbor.go.ro';
+$backup = 'https://api.laurentiumarian.ro';
 
 //Cluj server
 //$server = 'peviitor.go.ro';

--- a/v3/total/index.php
+++ b/v3/total/index.php
@@ -1,41 +1,109 @@
 <?php
+
 header("Access-Control-Allow-Origin: *");
 
 require_once '../config.php';
 
-$core = "jobs";
+class EndpointNotAvailableException extends Exception {}
 
-$qs = '?';
-$qs .= 'facet.field=company_str';
-$qs .= '&';
-$qs .= 'facet.limit=2000000';
-$qs .= '&';
-$qs .= 'facet=true';
-$qs .= '&';
-$qs .= 'fl=company';
-$qs .= '&';
-$qs .= 'indent=true';
-$qs .= '&';
-$qs .= 'q.op=OR';
-$qs .= '&';
-$qs .= 'q=*%3A*';
-$qs .= '&';
-$qs .= 'rows=0';
-$qs .= '&';
-$qs .= 'start=0';
-$qs .= '&';
-$qs .= 'useParams=';
+/**
+ * Builds a query string from an associative array of parameters.
+ *
+ * This function takes an array of key-value pairs and converts them into a URL-encoded
+ * query string. The resulting string starts with a question mark (?) followed by the
+ * encoded parameters.
+ *
+ * @param array $params An associative array of parameters to be included in the query string.
+ *                      The keys represent the parameter names, and the values represent the
+ *                      parameter values.
+ * 
+ * @return string The URL-encoded query string starting with a question mark (?).
+ */
+function buildQueryString(array $params): string {
+    return '?' . http_build_query($params);
+}
 
-$url = 'http://' . $server . '/solr/' . $core . '/select' . $qs;
+/**
+ * Fetches JSON data from a given URL.
+ *
+ * @param string $url The URL to fetch JSON data from.
+ * 
+ * @return array The decoded JSON data as an associative array.
+ * 
+ * @throws EndpointNotAvailableException If the endpoint is not available, 
+ *                                       if the content could not be retrieved, 
+ *                                       or if the JSON response is invalid.
+ */
+function fetchJsonData(string $url): array {
+    $headers = @get_headers($url);
 
-$string = file_get_contents($url);
-$json = json_decode($string, true);
+    if ($headers === false || strpos($headers[0], '200') === false) {
+        throw new EndpointNotAvailableException('Endpoint-ul nu este disponibil: ' . $url);
+    }
 
-$companies = $json['facet_counts']['facet_fields']['company_str'];
+    $response = file_get_contents($url);
+    if ($response === false) {
+        throw new EndpointNotAvailableException('Nu s-a putut obține conținutul de la: ' . $url);
+    }
 
-$obj = new stdClass();
-$obj->total = new stdClass();
-$obj->total->jobs = '' . $json['response']['numFound'];
-$obj->total->companies = '' . count($companies) / 2;
+    $json = json_decode($response, true);
+    if ($json === null) {
+        throw new EndpointNotAvailableException('Răspuns JSON invalid de la: ' . $url);
+    }
 
-echo json_encode($obj);
+    return $json;
+}
+
+try {
+    $core = "jobs";
+
+    $params = [
+        'facet.field' => 'company_str',
+        'facet.limit' => 2000000,
+        'facet' => 'true',
+        'fl' => 'company',
+        'indent' => 'true',
+        'q.op' => 'OR',
+        'q' => '*:*',
+        'rows' => 0,
+        'start' => 0,
+        'useParams' => ''
+    ];
+
+    $url = 'http://' . $server . '/solr/' . $core . '/select' . buildQueryString($params);
+
+    $json = fetchJsonData($url);
+
+    $companies = $json['facet_counts']['facet_fields']['company_str'] ?? [];
+    $totalJobs = $json['response']['numFound'] ?? 0;
+
+    $obj = (object) [
+        'total' => (object) [
+            'jobs' => (string) $totalJobs,
+            'companies' => (string) (count($companies) / 2)
+        ]
+    ];
+
+    echo json_encode($obj);
+
+} catch (EndpointNotAvailableException $e) {
+    $backupUrl = $backup . '/mobile/total/';
+
+    try {
+        $json = fetchJsonData($backupUrl);
+
+        $obj = (object) [
+            'total' => (object) [
+                'jobs' => (string) ($json['total'] ?? 0)
+            ]
+        ];
+
+        echo json_encode($obj);
+
+    } catch (Exception $backupException) {
+        echo json_encode([
+            'error' => 'Ambele endpoint-uri sunt indisponibile.',
+            'details' => $backupException->getMessage()
+        ]);
+    }
+}


### PR DESCRIPTION
Detailed Description:

This update introduces a fallback mechanism for cases when the primary Solr endpoint is unavailable. If the fallback server is used, the filtering functionality will not be applied, as the backup does not support the same filters.

Key Changes:
	•	Added a fallback to a backup server when the primary Solr endpoint is inaccessible.
	•	Highlighted limitation: filters are disabled when the backup server takes over.

Note:

This ensures the application continues to return results, albeit with limited functionality, during primary server downtime.