### PR TITLE
Fix DELETE /cleanjobs endpoint to accept company from query string

### DIFF
--- a/v0/cleanjobs/index.php
+++ b/v0/cleanjobs/index.php
@@ -3,60 +3,63 @@ header("Access-Control-Allow-Origin: *");
 header('Content-Type: application/json; charset=utf-8');
 
 if ($_SERVER['REQUEST_METHOD'] == 'DELETE') {
+    // Parse body for x-www-form-urlencoded data
     parse_str(file_get_contents('php://input'), $deleteData);
-    if (isset($deleteData['company'])) {
-        $company = trim($deleteData['company']);
 
-        if (empty($company)) {
-            http_response_code(400);
-            echo json_encode(['error' => 'Company name is required', 'code' => 400]);
-            exit;
-        }
+    // Accept both query (?company=) and body (form data)
+    $company = $_GET['company'] ?? $deleteData['company'] ?? null;
+    $company = $company !== null ? trim($company) : null;
 
-        // Load variables from the api.env file
-        require_once __DIR__ . '/../../util/loadEnv.php';
-        loadEnv(__DIR__ . '/../../api.env');
-
-        // Retrieve SOLR variables from environment
-        $server = getenv('LOCAL_SERVER') ?: ($_SERVER['LOCAL_SERVER'] ?? null);
-        $username = getenv('SOLR_USER') ?: ($_SERVER['SOLR_USER'] ?? null);
-        $password = getenv('SOLR_PASS') ?: ($_SERVER['SOLR_PASS'] ?? null);
-
-        // Debugging: Check if the server is set
-        if (!$server) {
-            die(json_encode(["error" => "LOCAL_SERVER is not set in api.env"]));
-        }
-        $core = 'jobs';
-
-        // Step 1: Get the count of jobs for the given company
-        $countUrl = "http://$server/solr/$core/select?q=" . rawurlencode('hiringOrganization.name:"' . $company . '"') . "&wt=json&rows=0";
-
-        $countResponse = fetchSolrData($countUrl);
-        if (!$countResponse) exit;
-
-        $jobCount = $countResponse['response']['numFound'] ?? 0;
-        if ($jobCount === 0) {
-            echo json_encode(['message' => 'No jobs found for the specified company', 'jobCount' => 0]);
-            exit;
-        }
-
-        // Step 2: Delete the jobs
-        $deleteUrl = "http://$server/solr/$core/update?commit=true&wt=json";
-        $deleteData = json_encode(['delete' => ['query' => 'hiringOrganization.name:"' . $company . '"']]);
-
-        $deleteResponse = fetchSolrData($deleteUrl, 'POST', $deleteData);
-        if (!$deleteResponse) exit;
-
-        echo json_encode(['message' => 'Jobs deleted successfully', 'jobCount' => $jobCount]);
-    } else {
+    if (empty($company)) {
         http_response_code(400);
-        echo json_encode(['error' => 'Company parameter is missing', 'code' => 400]);
+        echo json_encode(['error' => 'Company name is required', 'code' => 400]);
+        exit;
     }
+
+    // Load environment variables
+    require_once __DIR__ . '/../../util/loadEnv.php';
+    loadEnv(__DIR__ . '/../../api.env');
+
+    // Retrieve SOLR credentials
+    $server = getenv('LOCAL_SERVER') ?: ($_SERVER['LOCAL_SERVER'] ?? null);
+    $username = getenv('SOLR_USER') ?: ($_SERVER['SOLR_USER'] ?? null);
+    $password = getenv('SOLR_PASS') ?: ($_SERVER['SOLR_PASS'] ?? null);
+
+    if (!$server) {
+        http_response_code(500);
+        echo json_encode(["error" => "LOCAL_SERVER is not set in api.env"]);
+        exit;
+    }
+
+    $core = 'jobs';
+
+    // Step 1: Get the count of jobs for the given company
+    $countUrl = "http://$server/solr/$core/select?q=" . rawurlencode('hiringOrganization.name:"' . $company . '"') . "&wt=json&rows=0";
+    $countResponse = fetchSolrData($countUrl);
+    if (!$countResponse)
+        exit;
+
+    $jobCount = $countResponse['response']['numFound'] ?? 0;
+
+    if ($jobCount === 0) {
+        echo json_encode(['message' => 'No jobs found for the specified company', 'jobCount' => 0]);
+        exit;
+    }
+
+    // Step 2: Delete the jobs
+    $deleteUrl = "http://$server/solr/$core/update?commit=true&wt=json";
+    $deletePayload = json_encode(['delete' => ['query' => 'hiringOrganization.name:"' . $company . '"']]);
+    $deleteResponse = fetchSolrData($deleteUrl, 'POST', $deletePayload);
+    if (!$deleteResponse)
+        exit;
+
+    echo json_encode(['message' => 'Jobs deleted successfully', 'jobCount' => $jobCount]);
 } else {
     http_response_code(405);
     echo json_encode(['error' => 'Invalid request method', 'code' => 405]);
 }
 
+// Helper: Perform authenticated Solr request
 function fetchSolrData($url, $method = 'GET', $postData = null)
 {
     global $username, $password;
@@ -65,8 +68,8 @@ function fetchSolrData($url, $method = 'GET', $postData = null)
 
     $contextOptions = [
         'http' => [
-            'header'  => "Content-Type: application/json\r\n" . $authHeader,
-            'method'  => $method,
+            'header' => "Content-Type: application/json\r\n" . $authHeader,
+            'method' => $method,
             'content' => $postData ?: ""
         ]
     ];


### PR DESCRIPTION
## Description
This pull request updates the ```/cleanjobs/``` DELETE endpoint to correctly handle the ```company``` parameter when it is passed via query string (Params in Postman), not just via x-www-form-urlencoded body.

Previously, requests like

```DELETE /api/v0/cleanjobs/?company=Dedeman```

returned a ```400 Bad Request```with ```"Company parameter is missing"```.
This fix ensures the endpoint supports both body and query input.

### Changes

- Added support for reading the company value from $_GET as well as from the request body.
- Removed redundant condition blocks and simplified parameter validation.
- Preserved all existing Solr logic and response formats.

### Expected behavior


Input type | Example | Result
-- | -- | --
Query Params | DELETE /api/v0/cleanjobs/?company=Dedeman |  200 OK
Body (x-www-form-urlencoded) | company=Dedeman |  200 OK
Missing parameter | (no company) | 400 Bad Request with "Company name is required"
