### PR TITLE
Fix: enforce Content-Type application/json validation for update endpoint

### DIFF
--- a/v0/update/index.php
+++ b/v0/update/index.php
@@ -19,6 +19,17 @@ if ($_SERVER['REQUEST_METHOD'] !== 'PUT') {
     exit;
 }
 
+// Validate Content-Type header
+$contentType = $_SERVER["CONTENT_TYPE"] ?? $_SERVER["HTTP_CONTENT_TYPE"] ?? '';
+if (stripos($contentType, 'application/json') === false) {
+    http_response_code(415); // Unsupported Media Type
+    echo json_encode([
+        "error" => "Content-Type must be application/json",
+        "code" => 415
+    ]);
+    exit;
+}
+
 function city_fix($in)
 {
     $output = $in;


### PR DESCRIPTION
### Summary
The /api/v0/update/ endpoint was accepting PUT requests without validating the Content-Type header.  
This fix ensures the server returns an appropriate error (415 Unsupported Media Type) if the Content-Type is missing or invalid.

### Changes
- Added explicit Content-Type header validation for PUT requests
- Return 415 and JSON error message when header is not application/json
- Improved response consistency across error cases

### Testing
1. Send PUT request without `Content-Type: application/json`  
   Expected: HTTP 415 with error message  
2. Send PUT request with correct header  
   Expected: HTTP 200 with success message and data inserted into Solr

### Impact
Improves API robustness and compliance with REST standards.
