### PR TITLE
Fix: Return 400 Bad Request when unexpected fields are included in POST /logo/add

### DIFF
--- a/v0/logo/add/index.php
+++ b/v0/logo/add/index.php
@@ -41,6 +41,18 @@ if (!is_array($input)) {
     exit;
 }
 
+$allowedFields = ['id', 'logo'];
+$unexpectedFields = array_diff(array_keys($input), $allowedFields);
+
+if (!empty($unexpectedFields)) {
+    http_response_code(400);
+    echo json_encode([
+        "error" => "Unexpected fields detected: " . implode(', ', $unexpectedFields),
+        "code" => 400
+    ]);
+    exit;
+}
+
 $id = isset($input['id']) ? trim($input['id']) : null;
 $logo = isset($input['logo']) ? trim(htmlspecialchars($input['logo'])) : null;
 


### PR DESCRIPTION
### Summary
This PR fixes an issue where the POST /logo/add endpoint incorrectly returned 200 OK when extra fields were included in the request body.

### Changes
- Added validation to detect unexpected fields in the input JSON.
- Return 400 Bad Request with a descriptive error message when extra parameters are present.
- Ensured the response structure matches API consistency requirements.

### Testing
1. Send a POST request with only `id` and `logo` , expect 200 OK.
2. Send a POST request with `id`, `logo`, and any extra field , expect 400 Bad Request.
3. Verify the returned JSON matches the expected error format:
   ```json
   {
     "error": "Unexpected fields detected: extraField",
     "code": 400
   }

related to [#809](https://github.com/peviitor-ro/api/issues/809)
