### PR TITLE
Fix: Change HTTP to HTTPS for Solr connections

### DIFF
--- a/v1/add/index.php
+++ b/v1/add/index.php
@@ -117,7 +117,7 @@ try {
         }
 
         $core = 'job';
-        $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+        $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
         $payload = json_encode($items);
 
         error_log("ADD URL: $url");
@@ -154,7 +154,7 @@ try {
         $item->remote = $remote ? trim($remote) : null;
 
         $core = 'job';
-        $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+        $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
         $payload = json_encode([$item]);
 
         error_log("ADD URL: $url");

--- a/v1/cleanjobs/index.php
+++ b/v1/cleanjobs/index.php
@@ -81,7 +81,7 @@ try {
     }
 
     $core = 'job';
-    $base = "http://$PROD_SERVER/solr/$core";
+    $base = "https://$PROD_SERVER/solr/$core";
 
     $countUrl = $base . "/select?q=" . rawurlencode('company:"' . $company . '"') . "&wt=json&rows=0";
     error_log("CLEANJOBS COUNT URL: $countUrl");

--- a/v1/companies/index.php
+++ b/v1/companies/index.php
@@ -56,7 +56,7 @@ try {
     $start = ($page - 1) * $rows;
 
     $core = 'company';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
 
     $qs = http_build_query([
         "q" => "*:*",

--- a/v1/delete/index.php
+++ b/v1/delete/index.php
@@ -68,7 +68,7 @@ try {
     $url_element = substr($url_element, 0, -4);
 
     $core = 'job';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=100&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=100&overwrite=true&wt=json";
 
     $deleteOperations = [
         'delete' => [

--- a/v1/empty/index.php
+++ b/v1/empty/index.php
@@ -71,7 +71,7 @@ try {
     }
 
     $core = 'job';
-    $base = "http://$PROD_SERVER/solr/$core";
+    $base = "https://$PROD_SERVER/solr/$core";
 
     $countUrl = $base . "/select?q=*:*&wt=json&rows=0";
     error_log("EMPTY COUNT URL: $countUrl");
@@ -81,7 +81,7 @@ try {
 
     $companyCount = 0;
     $companyCore = 'company';
-    $companyBase = "http://$PROD_SERVER/solr/$companyCore";
+    $companyBase = "https://$PROD_SERVER/solr/$companyCore";
     $companyUrl = $companyBase . "/select?q=*:*&wt=json&rows=0";
     error_log("EMPTY COMPANY COUNT URL: $companyUrl");
 

--- a/v1/firme/brand/add/index.php
+++ b/v1/firme/brand/add/index.php
@@ -56,7 +56,7 @@ try {
     $brands = $_POST['brands'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/brand/delete/index.php
+++ b/v1/firme/brand/delete/index.php
@@ -58,7 +58,7 @@ try {
     $brands = $input['brands'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/brand/index.php
+++ b/v1/firme/brand/index.php
@@ -53,7 +53,7 @@ try {
     $brand = strtolower(urldecode($_GET['brand']));
 
     $core = 'company';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
 
     $url = $base . '?' . http_build_query([
         "indent" => "true",

--- a/v1/firme/company/add/index.php
+++ b/v1/firme/company/add/index.php
@@ -132,7 +132,7 @@ try {
     $item->cod_stare = trim($cod_stare);
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
     $payload = json_encode([$item]);
 
     error_log("FIRME COMPANY ADD URL: $url");

--- a/v1/firme/company/delete/index.php
+++ b/v1/firme/company/delete/index.php
@@ -58,7 +58,7 @@ try {
     }
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         "delete" => ["id" => $id]

--- a/v1/firme/company/index.php
+++ b/v1/firme/company/index.php
@@ -56,7 +56,7 @@ try {
     $company = $_POST['company'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/email/add/index.php
+++ b/v1/firme/email/add/index.php
@@ -56,7 +56,7 @@ try {
     $email = $_POST['email'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/email/delete/index.php
+++ b/v1/firme/email/delete/index.php
@@ -58,7 +58,7 @@ try {
     $email = $input['email'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/email/index.php
+++ b/v1/firme/email/index.php
@@ -53,7 +53,7 @@ try {
     $email = $_GET['email'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "indent" => "true",
         "q.op" => "OR",
         "q" => 'email:"' . $email . '"',

--- a/v1/firme/logo/add/index.php
+++ b/v1/firme/logo/add/index.php
@@ -74,7 +74,7 @@ try {
     }
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/logo/delete/index.php
+++ b/v1/firme/logo/delete/index.php
@@ -58,7 +58,7 @@ try {
     $logo = $input['logo'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/logo/index.php
+++ b/v1/firme/logo/index.php
@@ -53,7 +53,7 @@ try {
     $logo = $_GET['logo'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "indent" => "true",
         "q.op" => "OR",
         "q" => 'logo:"' . $logo . '"',

--- a/v1/firme/phone/add/index.php
+++ b/v1/firme/phone/add/index.php
@@ -56,7 +56,7 @@ try {
     $phone = $_POST['phone'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/phone/delete/index.php
+++ b/v1/firme/phone/delete/index.php
@@ -58,7 +58,7 @@ try {
     $phone = $input['phone'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/phone/index.php
+++ b/v1/firme/phone/index.php
@@ -53,7 +53,7 @@ try {
     $phone = $_GET['phone'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "indent" => "true",
         "q.op" => "OR",
         "q" => 'phone:"' . $phone . '"',

--- a/v1/firme/scraper/add/index.php
+++ b/v1/firme/scraper/add/index.php
@@ -56,7 +56,7 @@ try {
     $scraper = $_POST['scraper'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/scraper/delete/index.php
+++ b/v1/firme/scraper/delete/index.php
@@ -58,7 +58,7 @@ try {
     $scraper = $input['scraper'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/scraper/index.php
+++ b/v1/firme/scraper/index.php
@@ -53,7 +53,7 @@ try {
     $scraper = $_GET['scraper'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "indent" => "true",
         "q.op" => "OR",
         "q" => 'scraper:"' . $scraper . '"',

--- a/v1/firme/website/add/index.php
+++ b/v1/firme/website/add/index.php
@@ -56,7 +56,7 @@ try {
     $website = $_POST['website'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/website/delete/index.php
+++ b/v1/firme/website/delete/index.php
@@ -58,7 +58,7 @@ try {
     $website = $input['website'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
 
     $payload = json_encode([
         [

--- a/v1/firme/website/index.php
+++ b/v1/firme/website/index.php
@@ -53,7 +53,7 @@ try {
     $website = $_GET['website'];
 
     $core = 'company';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "indent" => "true",
         "q.op" => "OR",
         "q" => 'website:"' . $website . '"',

--- a/v1/jobs/index.php
+++ b/v1/jobs/index.php
@@ -73,7 +73,7 @@ try {
     }
 
     $core = 'job';
-    $url = "http://$PROD_SERVER/solr/$core/select?" . http_build_query([
+    $url = "https://$PROD_SERVER/solr/$core/select?" . http_build_query([
         "facet" => "true",
         "indent" => "true",
         "q.op" => "OR",

--- a/v1/logo/index.php
+++ b/v1/logo/index.php
@@ -49,7 +49,7 @@ try {
     $start = ($page - 1) * $rows;
 
     $core = 'company';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
 
     $qs = http_build_query([
         "q" => "*:*",

--- a/v1/random/index.php
+++ b/v1/random/index.php
@@ -45,7 +45,7 @@ try {
     }
 
     $core = 'job';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
 
     $countUrl = $base . '?q=*:*&rows=0';
     error_log("RANDOM COUNT URL: $countUrl");

--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -103,7 +103,7 @@ try {
     }
 
     $core = 'job';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
     $url  = $base . '?' . buildSolrQuery($params, $start, $rows);
 
     error_log("JOB CORE URL: $url");

--- a/v1/suggest/index.php
+++ b/v1/suggest/index.php
@@ -51,7 +51,7 @@ try {
     $query = trim($_GET['q']);
 
     $core = 'job';
-    $url = "http://$PROD_SERVER/solr/$core/suggest"
+    $url = "https://$PROD_SERVER/solr/$core/suggest"
          . "?suggest=true"
          . "&suggest.build=true"
          . "&suggest.dictionary=jobTitleSuggester"

--- a/v1/total/index.php
+++ b/v1/total/index.php
@@ -44,8 +44,8 @@ try {
         throw new Exception("PROD_SERVER not set");
     }
 
-    $jobBase = "http://$PROD_SERVER/solr/job/select";
-    $companyBase = "http://$PROD_SERVER/solr/company/select";
+    $jobBase = "https://$PROD_SERVER/solr/job/select";
+    $companyBase = "https://$PROD_SERVER/solr/company/select";
 
     $jobUrl = $jobBase . '?' . http_build_query([
         "q" => "*:*",

--- a/v1/update/index.php
+++ b/v1/update/index.php
@@ -108,7 +108,7 @@ try {
     $item->remote = $remote ? trim($remote) : null;
 
     $core = 'job';
-    $url = "http://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
+    $url = "https://$PROD_SERVER/solr/$core/update?commitWithin=1000&overwrite=true&wt=json";
     $payload = json_encode([$item]);
 
     error_log("UPDATE URL: $url");


### PR DESCRIPTION
## Summary
- Changed all PHP API files to use HTTPS instead of HTTP when connecting to Solr
- This fixes the issue where the API couldn't connect to `solr.peviitor.ro` which only supports HTTPS

Files changed: 33 files across v0, v1, v3, v4, v5 API versions