### PR TITLE
Fix: Remove mm=100% and change q.op to OR for better search

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -56,10 +56,9 @@ function fetchJson(string $url, ?string $user = null, ?string $pass = null, int 
 function buildSolrQuery(array $params, int $start, int $rows): string {
     $parts = [];
     $parts[] = 'indent=true';
-    $parts[] = 'q.op=AND';
+    $parts[] = 'q.op=OR';
     $parts[] = 'defType=edismax';
     $parts[] = 'qf=' . rawurlencode('title company location');
-    $parts[] = 'mm=100%25';
 
     $parts[] = !empty($params['q'])
         ? 'q=' . rawurlencode($params['q'])


### PR DESCRIPTION
## Summary
- Remove `mm=100%` which required ALL search terms to match exactly
- Change `q.op=AND` to `q.op=OR` for more flexible matching

This fixes the issue where searching for "EPAM" would return no results even though jobs exist.