### PR TITLE
Fix: Simplify Solr query - remove edismax and qf params

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -57,8 +57,6 @@ function buildSolrQuery(array $params, int $start, int $rows): string {
     $parts = [];
     $parts[] = 'indent=true';
     $parts[] = 'q.op=OR';
-    $parts[] = 'defType=edismax';
-    $parts[] = 'qf=' . rawurlencode('title company location');
 
     $parts[] = !empty($params['q'])
         ? 'q=' . rawurlencode($params['q'])


### PR DESCRIPTION
## Summary
- Remove `defType=edismax` and `qf` params from Solr query
- These params were causing 0 results to be returned even when jobs exist
- Simple query with `q.op=OR` now works correctly

Working URL format:
`https://solr.peviitor.ro/solr/job/select?q=EPAM&start=0&rows=12&q.op=OR`