### PR TITLE
Boost search results by data completeness

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -70,9 +70,19 @@ function buildSolrQuery(array $params, int $start, int $rows): string {
     $parts = [];
     $parts[] = 'indent=true';
     $parts[] = 'q.op=OR';
+    $parts[] = 'defType=edismax';
+    $parts[] = 'tie=1.0';
+
     $parts[] = !empty($params['q'])
         ? 'q=' . rawurlencode($params['q'])
         : 'q=*:*';
+
+    $parts[] = 'bq=salary:[*+TO+*]^10000';
+    $parts[] = 'bq=tags:[*+TO+*]^5000';
+    $parts[] = 'bq=cif:[*+TO+*]^2000';
+    $parts[] = 'bq=company:[*+TO+*]^500';
+    $parts[] = 'bq=title:[*+TO+*]^100';
+    $parts[] = 'bq=location:[*+TO+*]^50';
 
     $filters = [
         'company' => 'company',


### PR DESCRIPTION
## Summary
This PR implements a PageRank-style boost system to prioritize jobs with more complete data in search results.

## Changes
- Added defType=edismax and tie=1.0 to enable stronger boost influence
- Added boost queries (bq) with field priority:
  - salary: 10000
  - tags: 5000
  - cif: 2000
  - company: 500
  - title: 100
  - location: 50

## Testing
Tested with Solr queries - jobs with salary appear first, followed by jobs with tags, then cif, etc.

Closes #1022