### PR TITLE
Add workmode filter to v1/search endpoint

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -63,9 +63,9 @@ function buildSolrQuery(array $params, int $start, int $rows): string {
         : 'q=*:*';
 
     $filters = [
-        'company' => 'company',
-        'city'    => 'location',
-        'remote'  => 'workmode'
+        'company'  => 'company',
+        'city'     => 'location',
+        'workmode' => 'workmode'
     ];
 
     foreach ($filters as $param => $field) {


### PR DESCRIPTION
## Summary
- Added `workmode` as a valid query parameter in the `/v1/search/` endpoint
- Filter results in the Solr query by the `workmode` field
- Removed deprecated `remote` parameter

## Example Requests
```bash
# Get only on-site jobs
curl "https://api.peviitor.ro/v1/search/?workmode=on-site&page=1"

# Get only hybrid jobs
curl "https://api.peviitor.ro/v1/search/?workmode=hybrid&page=1"

# Get only remote jobs
curl "https://api.peviitor.ro/v1/search/?workmode=remote&page=1"
```

Closes #1025