### PR TITLE
Fix workmode filter and use HTTPS for Solr

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -129,7 +129,7 @@ try {
     }
 
     $core = 'job';
-    $base = "http://$PROD_SERVER/solr/$core/select";
+    $base = "https://$PROD_SERVER/solr/$core/select";
     $url  = $base . '?' . buildSolrQuery($params, $start, $rows);
 
     error_log("JOB CORE URL: $url");


### PR DESCRIPTION
## Summary
- Fix workmode filter in v1/search endpoint (was already fixed in code but may not have been deployed properly)
- Change HTTP to HTTPS for Solr connections (required for solr.peviitor.ro)

## Testing
- Verified workmode=remote returns 56 jobs in Solr
- Verified workmode=hybrid returns 477 jobs in Solr

## Related Issue
Fixes #1025