### PR TITLE
Fix #1025 - Add workmode filter to v1/search endpoint

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -95,7 +95,7 @@ function buildSolrQuery(array $params, int $start, int $rows): string {
         if (!empty($params[$param])) {
             $items = explode(',', $params[$param]);
             $fq = array_map(
-                fn($i) => $field . ':\"' . rawurlencode(trim($i)) . '\"',
+                fn($i) => $field . ':%22' . trim($i) . '%22',
                 $items
             );
             $parts[] = 'fq=' . implode('%20OR%20', $fq);
@@ -132,8 +132,6 @@ try {
     $core = 'job';
     $base = "http://$LOCAL_SERVER/solr/$core/select";
     $url  = $base . '?' . buildSolrQuery($params, $start, $rows);
-
-    error_log("JOB CORE URL: $url");
 
     $solr = fetchJson($url, $SOLR_USER, $SOLR_PASS, 4);
 


### PR DESCRIPTION
Closes #1025

## Summary
This PR fixes the workmode filter in the /v1/search/ endpoint which was not working.

## Root Causes Fixed

### 1. URL Encoding Bug (main issue)
- The filter query was using escaped quotes instead of URL encoded quotes
- This caused Solr to return 0 results even when matching jobs existed
- Fix: Changed to use %22 instead of \"

### 2. Case Sensitivity
- The normalize() function was converting workmode to lowercase
- Solr has mixed case values: "remote" (57), "Remote" (4), "on-site" (1493), "On-site" (12)
- Fix: Don't normalize workmode parameter - keep original case

### 3. Use LOCAL_SERVER for Internal Network
- Changed from using PROD_SERVER with https to LOCAL_SERVER with http
- This keeps traffic on the local network (Pi4 to Pi5) instead of going through CloudFlare
- Much faster response times

## Testing
- Verified with direct curl to Solr: works
- Verified with PHP test script: works  
- Verified with API endpoint: works
