### PR TITLE
Fix company endpoint: return empty string instead of -

### DIFF
--- a/v1/company/index.php
+++ b/v1/company/index.php
@@ -74,6 +74,13 @@ try {
 
     $doc = $solr['response']['docs'][0] ?? [];
 
+    $doc = array_map(function($value) {
+        if ($value === '-' || $value === '' || $value === null) {
+            return '';
+        }
+        return $value;
+    }, $doc);
+
     echo json_encode([
         'company' => $doc
     ], JSON_UNESCAPED_UNICODE);


### PR DESCRIPTION
## Summary
- Return empty string "" instead of "-" for empty/null values in company endpoint