### PR TITLE
Fix normalize function to remove dots and commas from company names

### DIFF
--- a/v1/search/index.php
+++ b/v1/search/index.php
@@ -40,7 +40,9 @@ function normalize(string $v): string {
         'ă'=>'a','â'=>'a','î'=>'i','ș'=>'s','ş'=>'s','ț'=>'t','ţ'=>'t',
         'Ă'=>'a','Â'=>'a','Î'=>'i','Ș'=>'s','Ş'=>'s','Ț'=>'t','Ţ'=>'t'
     ];
-    return strtr(mb_strtolower(trim($v), 'UTF-8'), $map);
+    $v = strtr(mb_strtolower(trim($v), 'UTF-8'), $map);
+    $v = preg_replace('/[.,;:]/', '', $v);
+    return $v;
 }
 
 function fetchJson(string $url, ?string $user = null, ?string $pass = null, int $timeout = 5): array {


### PR DESCRIPTION
Fixes API search returning 404 when company name has dots like S.R.L. instead of SRL

Problem: normalize() function was keeping dots and commas from company names after lowercasing, causing search to fail when frontend sends 'S.R.L.' but SOLR has 'SRL'

Solution: Added preg_replace('/[.,;:]/', '', $v) to remove dots, commas and other punctuation