### PR TITLE
Add name parameter to v1/company endpoint for filtering companies by name

### DIFF
--- a/v1/company/index.php
+++ b/v1/company/index.php
@@ -46,6 +46,8 @@ try {
 
     $cif = $_GET['cif'] ?? '';
     $name = $_GET['name'] ?? '';
+    $page = isset($_GET['page']) ? max(0, (int)$_GET['page']) : 0;
+    $rows = isset($_GET['rows']) ? min(100, max(1, (int)$_GET['rows'])) : 100;
 
     if (empty($cif) && empty($name)) {
         http_response_code(400);
@@ -59,7 +61,8 @@ try {
     if (!empty($name)) {
         $qs = http_build_query([
             "q" => "name:*" . rawurlencode($name) . "*",
-            "rows" => 100,
+            "start" => $page * $rows,
+            "rows" => $rows,
             "indent" => "true"
         ]);
     } else {
@@ -82,18 +85,36 @@ try {
         exit;
     }
 
-    $doc = $solr['response']['docs'][0] ?? [];
+    if (!empty($name)) {
+        $docs = $solr['response']['docs'] ?? [];
+        $docs = array_map(function($doc) {
+            return array_map(function($value) {
+                if ($value === '-' || $value === '' || $value === null) {
+                    return '';
+                }
+                return $value;
+            }, $doc);
+        }, $docs);
 
-    $doc = array_map(function($value) {
-        if ($value === '-' || $value === '' || $value === null) {
-            return '';
-        }
-        return $value;
-    }, $doc);
+        echo json_encode([
+            'total' => $numFound,
+            'page' => $page,
+            'rows' => $rows,
+            'companies' => $docs
+        ], JSON_UNESCAPED_UNICODE);
+    } else {
+        $doc = $solr['response']['docs'][0] ?? [];
+        $doc = array_map(function($value) {
+            if ($value === '-' || $value === '' || $value === null) {
+                return '';
+            }
+            return $value;
+        }, $doc);
 
-    echo json_encode([
-        'company' => $doc
-    ], JSON_UNESCAPED_UNICODE);
+        echo json_encode([
+            'company' => $doc
+        ], JSON_UNESCAPED_UNICODE);
+    }
 
 } catch (Exception $e) {
     error_log("COMPANY FAILED: " . $e->getMessage());


### PR DESCRIPTION
## Descriere
Endpoint-ul v1/company permitea doar cautarea dupa CIF. Am adaugat parametrul name pentru cautare dupa nume.

## Modificari
- Fisier: v1/company/index.php
- Parametri noi: name, page, rows

## Utilizare
GET /v1/company/?name=EPA
GET /v1/company/?name=EPA&page=0&rows=10

## Parametri
cif - Cautare dupa CIF
name - Cautare dupa nume (partiala)
page - Numarul paginii (incepe de la 0)
rows - Numarul de rezultate pe pagina (max: 100)

Fixes #1063