### PR TITLE
fix: search by company field instead of name in Solr

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,6 +19,6 @@ jobs:
       - name: Deploy to Pi4
         run: |
           cd /home/sebi/peviitor-api
-          git stash
+          git config pull.rebase false
           git pull origin master
           docker exec peviitor-api apache2ctl graceful 2>/dev/null || docker restart peviitor-api

--- a/v1/company/index.php
+++ b/v1/company/index.php
@@ -60,7 +60,7 @@ try {
 
     if (!empty($name)) {
         $qs = http_build_query([
-            "q" => "name:*" . rawurlencode($name) . "*",
+            "q" => "company:*" . rawurlencode($name) . "*",
             "start" => $page * $rows,
             "rows" => $rows,
             "indent" => "true"


### PR DESCRIPTION
## Summary
- Fix endpoint /v1/company/?name=... to search by company field instead of name field in Solr
- The name field does not exist in the company core, causing Company not found errors

## Testing
Tested on pi4.local:
GET /v1/company/?name=EPAM
Returns 9 companies including EPAM SYSTEMS INTERNATIONAL SRL