### PR TITLE
Add .htaccess to protect .env files from public access

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,3 @@
+<FilesMatch "\.env$">
+    Require all denied
+</FilesMatch>


### PR DESCRIPTION
## Summary

- Added `.htaccess` file that blocks public access to `.env` files (including `api.env`)
- Currently `https://api.peviitor.ro/api.env` is publicly accessible, exposing credentials
- After merge and deploy, accessing `.env` files will return **403 Forbidden**

## What this fixes

Access to `.env` configuration files via HTTP. Fixes #1072.

## What remains to be addressed (from #1072)

1. **Move `.env` outside web root** â€“ more secure than just blocking via `.htaccess`
2. **Restrict Solr access** â€“ ensure Solr is not publicly exposed or properly firewalled
3. **Rotate compromised credentials** â€“ since `api.env` was publicly accessible, all secrets should be rotated
4. **Audit logs** for unauthorized access to `api.env`

## Security Impact

This is the first step in mitigating the critical vulnerability. Blocking `.env` files via `.htaccess` prevents casual access, but the most secure long-term solution is to move the file outside the document root.
