### PR TITLE
feat: add auth + brand lookup to v1/cleanjobs endpoint

### DIFF
--- a/INSTRUCTIONS.md
+++ b/INSTRUCTIONS.md
@@ -13,7 +13,7 @@ This is the source code for **api.peviitor.ro**, a REST API for a Romanian job b
 ```
 api/
 ├── v0/          # Jobs & Companies API (TEST environment)
-├── v1/          # (empty - to be developed for PROD)
+├── v1/          # PROD endpoints (random, empty, + altele în lucru)
 ├── v3/          # Extended version with logo/images
 ├── v4/          # Download-focused version
 ├── v5/          # Simplified jobs API
@@ -50,7 +50,10 @@ api/
 - `/firme/website/` - GET, POST (add), DELETE
 - `/firme/scraper/` - GET, POST (add), DELETE
 
-### v1 (PROD - empty, to be developed)
+### v1 (PROD - in development)
+Endpoints: `/random/`, `/empty/`, `/total/`, `/companies/`, `/search/`, `/suggest/`, `/jobs/`, `/add/`, `/update/`, `/delete/`, `/logo/`, `/images/`, `/firme/`, `/health/`
+- `random` și `empty` — revizuite și documentate pe api.peviitor.ro
+- Celelalte în dezvoltare
 
 ### v3
 Similar to v0 plus:

--- a/devops/clean-db.sh
+++ b/devops/clean-db.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+set -e
+
+echo "Step 1: Cleaning all jobs from DB..."
+curl -s -X DELETE "https://api.peviitor.ro/v1/empty/" \
+  -H "X-API-Key: ff564852-8c9f-4ef0-adca-b2987a4b960b" \
+  -H "X-Cleanup-Secret: 62a8b3a0-c6e0-4aa0-b96b-40bc6ef92e64" \
+  -H "Content-Type: application/json" \
+  -d '{"confirmation": "DELETE_ALL_DATA"}' | jq .
+
+echo ""
+echo "Step 2: Verifying jobs are 0..."
+sleep 2
+TOTAL=$(curl -s "https://api.peviitor.ro/v1/total/" -H "Accept: application/json")
+echo "$TOTAL" | jq .
+JOBS=$(echo "$TOTAL" | jq -r '.total.jobs')
+
+if [ "$JOBS" -eq 0 ]; then
+  echo ""
+  echo "Step 3: Triggering import workflow..."
+  gh workflow run import.yml --repo sebiboga/peviitor-joblio-scraper
+  echo "Import workflow triggered successfully!"
+else
+  echo "Jobs still present ($JOBS), not triggering import."
+  exit 1
+fi

--- a/devops/trigger-all-scrapers.sh
+++ b/devops/trigger-all-scrapers.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# Trigger all scrapers from repos with topic "job-seeker-ro-spider"
+
+set -e
+
+REPOS=(
+  # sebiboga repos
+  "sebiboga/rapel-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/e-infra-sa-python-scraper:scraper.yml"
+  "sebiboga/mol-romania-petroleum-products-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/randstad-romania-nodejs-scraper:scrape.yml"
+  "sebiboga/secpral-pro-instalatii-srl-nodejs-scraper:run-spishop.yml"
+  "sebiboga/epam-systems-international-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/co-era-bc-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/artsoft-consult-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/bitdefender-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/tec-software-solutions-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/unix-auto-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/ropardo-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/ascom-mobile-solutions-romania-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/borgdesign-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/ciklum-romania-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/mejix-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/endava-romania-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/tickbird-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/ahold-delhaize-technologies-srl-nodejs-scraper:scrape.yml"
+  "sebiboga/msg-systems-romania-srl-nodejs-scraper:scrape.yml"
+  # other users repos
+  "cristian-alexutan/robert-bosch-srl-nodejs-scraper:scrape.yml"
+  "BalaciSofia/frequentis-romania-srl-nodejs-scraper:scrape.yml"
+  "emtreila/qubiz-srl-nodejs-scraper:scrape.yml"
+  "BalaciSofia/rebeldot-solutions-srl-nodejs-scraper:scrape.yml"
+  "cristian-alexutan/lateral-group-srl-nodejs-scraper:scrape.yml"
+  "emtreila/yonder-srl-nodejs-scraper:scrape.yml"
+  "carmenioanaa/arrise-srl-nodejs-scraper:scrape.yml"
+  "AlexColceriu/eighteengym-srl-nodejs-scraper:scrape.yml"
+  "peviitor-ro/Scrapers_Cristi_Olteanu_2:scrapers_runner.yml"
+)
+
+echo "Triggering all scrapers..."
+
+for entry in "${REPOS[@]}"; do
+  REPO="${entry%%:*}"
+  WORKFLOW="${entry##*:}"
+
+  echo -n "→ $REPO ($WORKFLOW) ... "
+  if gh workflow run "$WORKFLOW" --repo "$REPO" 2>/dev/null; then
+    echo "✅ triggered"
+  else
+    echo "❌ failed"
+  fi
+done
+
+echo ""
+echo "Done! All scrapers triggered."

--- a/index.php
+++ b/index.php
@@ -636,6 +636,180 @@
 
   </div>
 
+  <!-- ============================================= -->
+  <!-- CLEANJOBS ENDPOINT -->
+  <!-- ============================================= -->
+
+  <div class="card">
+    <div class="endpoint-row endpoint-row-delete" onclick="toggleEndpoint('cleanjobs')">
+      <span class="method-badge method-badge-delete">DELETE</span>
+      <span class="endpoint-path">/v1/cleanjobs/</span>
+      <span class="endpoint-desc" data-i18n="cleanjobsTag">Delete job records for a company</span>
+      <span class="toggle-arrow" id="arrow-cleanjobs">&#9654;</span>
+    </div>
+  </div>
+
+  <div id="cleanjobs-content" class="endpoint-content" style="display:none">
+
+    <div class="card">
+      <div class="card-body">
+        <div class="warning-banner" data-i18n="cleanjobsWarning">
+          <strong>Warning:</strong> This action permanently deletes ALL job records for the specified company from the Solr database. This cannot be undone.
+        </div>
+
+        <p style="margin-bottom:1rem;color:#5a4a3a;" data-i18n="cleanjobsDesc">
+          Permanently deletes every job document matching the given company from the <code>job</code> Solr core.
+          Designed for company website owners who want to remove their listings from the peviitor platform.
+        </p>
+
+        <div class="section-title" data-i18n="howItWorksTitle">How it works</div>
+        <ol style="margin:0 0 1.5rem 1.2rem;color:#5a4a3a;font-size:0.9rem;">
+          <li data-i18n="cleanjobsHow1">Identify the company by <code>company</code> name, <code>cif</code>, or <code>brand</code></li>
+          <li data-i18n="cleanjobsHow2">Compute <code>X-Api-Key</code> as MD5 hash based on the provided identifiers</li>
+          <li data-i18n="cleanjobsHow3">Send a DELETE request with confirmation body</li>
+          <li data-i18n="cleanjobsHow4">All matching jobs are permanently removed from the index</li>
+        </ol>
+
+        <div class="section-title" data-i18n="authTitle">Authentication</div>
+        <p style="margin-bottom:1rem;color:#5a4a3a;font-size:0.9rem;" data-i18n="cleanjobsAuthDesc">
+          You must provide an <code>X-Api-Key</code> header computed as <code>md5()</code> of the identifiers you send.
+          The key is generated from the same fields in the request body:
+        </p>
+        <table class="prop-table" style="margin-bottom:1.5rem;">
+          <thead><tr><th>Body fields</th><th>X-Api-Key formula</th></tr></thead>
+          <tbody>
+            <tr><td><code>company</code> + <code>cif</code></td><td><code>md5(company + cif)</code> <span style="color:#4a7c5a;font-size:0.8rem;">(recommended)</span></td></tr>
+            <tr><td><code>company</code> only</td><td><code>md5(company)</code></td></tr>
+            <tr><td><code>brand</code> only</td><td><code>md5(brand)</code></td></tr>
+          </tbody>
+        </table>
+
+        <div class="section-title" data-i18n="cleanjobsBodyTitle">Request body</div>
+        <pre>{
+  <span class="json-key">"company"</span>: <span class="json-string">"NUME SRL"</span>,
+  <span class="json-key">"cif"</span>: <span class="json-string">"12345678"</span>,
+  <span class="json-key">"confirmation"</span>: <span class="json-string">"CLEAN_COMPANY_JOBS"</span>
+}</pre>
+        <p style="margin:0.5rem 0 0;color:#7d6b5a;font-size:0.85rem;" data-i18n="cleanjobsBodyNote">
+          At least one of <code>company</code>, <code>cif</code>, or <code>brand</code> is required.
+          The <code>confirmation</code> field must be exactly <code>"CLEAN_COMPANY_JOBS"</code>.
+        </p>
+
+        <div class="section-title" data-i18n="tryItTitle">Try it</div>
+        <div class="curl-box">
+          <div class="curl-label">curl</div>
+          <pre>COMPANY="NUME SRL"
+CIF="12345678"
+KEY=$(echo -n "${COMPANY}${CIF}" | md5sum | cut -d' ' -f1)
+
+curl -X DELETE "https://api.peviitor.ro/v1/cleanjobs/" \
+  -H "X-Api-Key: $KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "company": "'"$COMPANY"'",
+    "cif": "'"$CIF"'",
+    "confirmation": "CLEAN_COMPANY_JOBS"
+  }'</pre>
+        </div>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" data-i18n="cleanjobsRespTitle">Response fields</div>
+      <div class="card-body">
+        <table class="prop-table">
+          <thead><tr><th>Field</th><th>Type</th><th data-i18n="description">Description</th></tr></thead>
+          <tbody>
+            <tr><td>message</td><td><span class="type-tag">string</span></td><td data-i18n="cleanjobsRespMessage">Success confirmation message</td></tr>
+            <tr><td>jobCount</td><td><span class="type-tag">number</span></td><td data-i18n="cleanjobsRespJobCount">Number of jobs deleted</td></tr>
+            <tr><td>company</td><td><span class="type-tag">string</span></td><td data-i18n="cleanjobsRespCompany">Company name (if provided)</td></tr>
+            <tr><td>cif</td><td><span class="type-tag">string</span></td><td data-i18n="cleanjobsRespCif">Company CIF (if provided)</td></tr>
+            <tr><td>brand</td><td><span class="type-tag">string</span></td><td data-i18n="cleanjobsRespBrand">Company brand (if provided)</td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" data-i18n="successTitle">200 — Success</div>
+      <div class="card-body">
+        <pre>{
+  <span class="json-key">"message"</span>: <span class="json-string">"Jobs deleted successfully"</span>,
+  <span class="json-key">"jobCount"</span>: <span class="json-number">42</span>,
+  <span class="json-key">"company"</span>: <span class="json-string">"NUME SRL"</span>,
+  <span class="json-key">"cif"</span>: <span class="json-string">"12345678"</span>
+}</pre>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">401 — <span data-i18n="unauthTitle">Unauthorized</span></div>
+      <div class="card-body">
+        <pre>{
+  <span class="json-key">"error"</span>: <span class="json-string">"Unauthorized - invalid X-Api-Key"</span>
+}</pre>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">404 — <span data-i18n="cleanjobsNotFoundTitle">No Jobs Found</span></div>
+      <div class="card-body">
+        <pre>{
+  <span class="json-key">"error"</span>: <span class="json-string">"No jobs found"</span>,
+  <span class="json-key">"message"</span>: <span class="json-string">"No jobs found matching the given criteria"</span>
+}</pre>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">405 — <span data-i18n="methodNotAllowedTitle">Method Not Allowed</span></div>
+      <div class="card-body">
+        <pre>{
+  <span class="json-key">"error"</span>: <span class="json-string">"Only DELETE method allowed"</span>
+}</pre>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header">503 — <span data-i18n="unavailTitle">Service Unavailable</span></div>
+      <div class="card-body">
+        <pre>{
+  <span class="json-key">"error"</span>: <span class="json-string">"Job core unavailable"</span>,
+  <span class="json-key">"details"</span>: <span class="json-string">"PROD_SERVER not set"</span>
+}</pre>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header"><span data-i18n="requirementsTitle">Requirements</span> &mdash; <span data-i18n="cleanjobsEndpoint">Cleanjobs</span></div>
+      <div class="card-body">
+        <table class="prop-table">
+          <thead><tr><th style="width:120px" data-i18n="item">Item</th><th data-i18n="details">Details</th></tr></thead>
+          <tbody>
+            <tr><td data-i18n="method">Method</td><td><code>DELETE</code> only</td></tr>
+            <tr><td data-i18n="auth">Auth</td><td><code>X-Api-Key: md5(company + cif)</code> (or <code>md5(company)</code> / <code>md5(brand)</code>)</td></tr>
+            <tr><td data-i18n="params">Params</td><td data-i18n="cleanjobsParamsVal">Body: <code>{"company"?: "...", "cif"?: "...", "brand"?: "...", "confirmation": "CLEAN_COMPANY_JOBS"}</code></td></tr>
+            <tr><td data-i18n="contentType">Content-Type</td><td><code>application/json</code></td></tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+
+    <div class="card">
+      <div class="card-header" data-i18n="statusCodesTitle">Status codes</div>
+      <div class="card-body">
+        <ul class="status-list">
+          <li><span class="status-code sc-200">200</span><span data-i18n="cleanjobsStatus200">Jobs were deleted successfully</span></li>
+          <li><span class="status-code sc-401" style="background:#ffebee;color:#c62828;">401</span><span data-i18n="cleanjobsStatus401">Invalid or missing X-Api-Key header</span></li>
+          <li><span class="status-code sc-404">404</span><span data-i18n="cleanjobsStatus404">No jobs found matching the given criteria</span></li>
+          <li><span class="status-code sc-405" style="background:#e8eaf6;color:#283593;">405</span><span data-i18n="cleanjobsStatus405">Only DELETE method is allowed</span></li>
+          <li><span class="status-code sc-503">503</span><span data-i18n="cleanjobsStatus503">Solr core is unavailable or environment not configured</span></li>
+        </ul>
+      </div>
+    </div>
+
+  </div>
+
   <h2 data-i18n="statusTitle">Stare curentă a API-ului</h2>
   <p class="section-desc" data-i18n="statusDesc">Lucrăm la:</p>
   <ul class="future-list">
@@ -730,6 +904,31 @@ const i18n = {
     emptyAuthReq: "<code>X-API-Key</code> + <code>X-Cleanup-Secret</code> (production only)",
     emptyParamsVal: "Body: <code>{\"confirmation\": \"DELETE_ALL_DATA\"}</code>",
 
+    cleanjobsTag: "Delete job records for a company",
+    cleanjobsWarning: "<strong>Warning:</strong> This action permanently deletes ALL job records for the specified company from the Solr database. This cannot be undone.",
+    cleanjobsDesc: "Permanently deletes every job document matching the given company from the <code>job</code> Solr core. Designed for company website owners who want to remove their listings from the peviitor platform.",
+    cleanjobsHow1: "Identify the company by <code>company</code> name, <code>cif</code>, or <code>brand</code>",
+    cleanjobsHow2: "Compute <code>X-Api-Key</code> as MD5 hash based on the provided identifiers",
+    cleanjobsHow3: "Send a DELETE request with confirmation body",
+    cleanjobsHow4: "All matching jobs are permanently removed from the index",
+    cleanjobsAuthDesc: "You must provide an <code>X-Api-Key</code> header computed as <code>md5()</code> of the identifiers you send. The key is generated from the same fields in the request body:",
+    cleanjobsBodyTitle: "Request body",
+    cleanjobsBodyNote: "At least one of <code>company</code>, <code>cif</code>, or <code>brand</code> is required. The <code>confirmation</code> field must be exactly <code>\"CLEAN_COMPANY_JOBS\"</code>.",
+    cleanjobsRespTitle: "Response fields",
+    cleanjobsRespMessage: "Success confirmation message",
+    cleanjobsRespJobCount: "Number of jobs deleted",
+    cleanjobsRespCompany: "Company name (if provided)",
+    cleanjobsRespCif: "Company CIF (if provided)",
+    cleanjobsRespBrand: "Company brand (if provided)",
+    cleanjobsNotFoundTitle: "No Jobs Found",
+    cleanjobsEndpoint: "Cleanjobs",
+    cleanjobsParamsVal: "Body: <code>{\"company\"?: \"...\", \"cif\"?: \"...\", \"brand\"?: \"...\", \"confirmation\": \"CLEAN_COMPANY_JOBS\"}</code>",
+    cleanjobsStatus200: "Jobs were deleted successfully",
+    cleanjobsStatus401: "Invalid or missing X-Api-Key header",
+    cleanjobsStatus404: "No jobs found matching the given criteria",
+    cleanjobsStatus405: "Only DELETE method is allowed",
+    cleanjobsStatus503: "Solr core is unavailable or environment not configured",
+
     contextParagraph: "This page exposes public endpoints of the peviitor.ro API, a job discovery platform. We are in the process of reviewing and expanding the API, and the documentation will gradually improve.",
     availableEndpointsTitle: "Currently available endpoints",
     availableEndpointsDesc: "The endpoints below are available right now and can be used for testing and exploration. The API is being standardized, and we will gradually publish new endpoints along with more detailed documentation.",
@@ -809,6 +1008,31 @@ const i18n = {
     randomEndpoint: "Endpoint aleator",
     emptyAuthReq: "<code>X-API-Key</code> + <code>X-Cleanup-Secret</code> (doar production)",
     emptyParamsVal: "Body: <code>{\"confirmation\": \"DELETE_ALL_DATA\"}</code>",
+
+    cleanjobsTag: "\u0218terge \u00EEnregistr\u0103rile de joburi pentru o companie",
+    cleanjobsWarning: "<strong>Aten\u021Bie:</strong> Aceast\u0103 ac\u021Biune \u0219terge PERMANENT toate joburile pentru compania specificat\u0103 din baza de date Solr. Nu poate fi anulat\u0103.",
+    cleanjobsDesc: "\u0218terge permanent toate documentele de job care corespund companiei date din core-ul Solr <code>job</code>. Conceput pentru proprietarii de website-uri de companii care doresc s\u0103 \u00EE\u0219i elimine list\u0103rile de pe platforma peviitor.",
+    cleanjobsHow1: "Identific\u0103 compania dup\u0103 numele <code>company</code>, <code>cif</code> sau <code>brand</code>",
+    cleanjobsHow2: "Calculeaz\u0103 <code>X-Api-Key</code> ca hash MD5 pe baza identificatorilor furniza\u021Bi",
+    cleanjobsHow3: "Trimite un request DELETE cu corpul de confirmare",
+    cleanjobsHow4: "Toate joburile corespunz\u0103toare sunt eliminate permanent din index",
+    cleanjobsAuthDesc: "Trebuie s\u0103 furnizezi un header <code>X-Api-Key</code> calculat ca <code>md5()</code> al identificatorilor trimi\u0219i. Cheia se genereaz\u0103 din acelea\u0219i c\u00E2mpuri din corpul requestului:",
+    cleanjobsBodyTitle: "Corpul requestului",
+    cleanjobsBodyNote: "Cel pu\u021Bin unul dintre <code>company</code>, <code>cif</code> sau <code>brand</code> este obligatoriu. C\u00E2mpul <code>confirmation</code> trebuie s\u0103 fie exact <code>\"CLEAN_COMPANY_JOBS\"</code>.",
+    cleanjobsRespTitle: "C\u00E2mpurile r\u0103spunsului",
+    cleanjobsRespMessage: "Mesaj de confirmare a succesului",
+    cleanjobsRespJobCount: "Num\u0103rul de joburi \u0219terse",
+    cleanjobsRespCompany: "Numele companiei (dac\u0103 a fost furnizat)",
+    cleanjobsRespCif: "CIF-ul companiei (dac\u0103 a fost furnizat)",
+    cleanjobsRespBrand: "Brandul companiei (dac\u0103 a fost furnizat)",
+    cleanjobsNotFoundTitle: "Niciun job g\u0103sit",
+    cleanjobsEndpoint: "Endpoint cur\u0103\u021Bare joburi",
+    cleanjobsParamsVal: "Body: <code>{\"company\"?: \"...\", \"cif\"?: \"...\", \"brand\"?: \"...\", \"confirmation\": \"CLEAN_COMPANY_JOBS\"}</code>",
+    cleanjobsStatus200: "Joburile au fost \u0219terse cu succes",
+    cleanjobsStatus401: "Header X-Api-Key invalid sau lips\u0103",
+    cleanjobsStatus404: "Nu s-au g\u0103sit joburi care s\u0103 corespund\u0103 criteriilor date",
+    cleanjobsStatus405: "Doar metoda DELETE este permis\u0103",
+    cleanjobsStatus503: "Core-ul Solr este indisponibil sau mediul nu este configurat",
 
     contextParagraph: "Această pagină expune endpoint-uri publice ale API-ului peviitor.ro, o platformă de descoperire a joburilor. Suntem în proces de revizuire și extindere a API-ului, iar documentația se va îmbunătăți treptat.",
     availableEndpointsTitle: "Endpoint-uri disponibile în prezent",

--- a/index.php
+++ b/index.php
@@ -928,6 +928,7 @@ const i18n = {
     cleanjobsStatus404: "No jobs found matching the given criteria",
     cleanjobsStatus405: "Only DELETE method is allowed",
     cleanjobsStatus503: "Solr core is unavailable or environment not configured",
+    unauthTitle: "Unauthorized",
 
     contextParagraph: "This page exposes public endpoints of the peviitor.ro API, a job discovery platform. We are in the process of reviewing and expanding the API, and the documentation will gradually improve.",
     availableEndpointsTitle: "Currently available endpoints",
@@ -1033,6 +1034,7 @@ const i18n = {
     cleanjobsStatus404: "Nu s-au g\u0103sit joburi care s\u0103 corespund\u0103 criteriilor date",
     cleanjobsStatus405: "Doar metoda DELETE este permis\u0103",
     cleanjobsStatus503: "Core-ul Solr este indisponibil sau mediul nu este configurat",
+    unauthTitle: "Neautorizat",
 
     contextParagraph: "Această pagină expune endpoint-uri publice ale API-ului peviitor.ro, o platformă de descoperire a joburilor. Suntem în proces de revizuire și extindere a API-ului, iar documentația se va îmbunătăți treptat.",
     availableEndpointsTitle: "Endpoint-uri disponibile în prezent",

--- a/v1/cleanjobs/index.php
+++ b/v1/cleanjobs/index.php
@@ -65,51 +65,185 @@ function postJson(string $url, string $payload, ?string $user = null, ?string $p
     return $json;
 }
 
+function solrEscape(string $value): string {
+    $special = ['+', '-', '&', '|', '!', '(', ')', '{', '}', '[', ']', '^', '"', '~', '*', '?', ':', '\\', '/'];
+    $result = '';
+    for ($i = 0; $i < strlen($value); $i++) {
+        $char = $value[$i];
+        if (in_array($char, $special, true)) {
+            $result .= '\\' . $char;
+        } else {
+            $result .= $char;
+        }
+    }
+    return $result;
+}
+
 try {
     if (!$PROD_SERVER) {
         throw new Exception("PROD_SERVER not set");
     }
 
-    parse_str(file_get_contents('php://input'), $deleteData);
-    $company = $_GET['company'] ?? $deleteData['company'] ?? null;
-    $company = $company !== null ? trim($company) : null;
+    // Parse body - support JSON and form-encoded
+    $rawBody = file_get_contents('php://input');
+    $contentType = $_SERVER['CONTENT_TYPE'] ?? '';
 
-    if (empty($company)) {
+    if (strpos($contentType, 'application/json') !== false) {
+        $body = json_decode($rawBody, true);
+        if (!is_array($body)) {
+            http_response_code(400);
+            echo json_encode(['error' => 'Invalid JSON body']);
+            exit;
+        }
+    } else {
+        parse_str($rawBody, $body);
+    }
+
+    // Extract fields from body
+    $company     = isset($body['company']) ? trim($body['company']) : null;
+    $cif         = isset($body['cif']) ? trim($body['cif']) : null;
+    $brand       = isset($body['brand']) ? trim($body['brand']) : null;
+    $confirmation = isset($body['confirmation']) ? trim($body['confirmation']) : null;
+
+    // Validate: at least one identifier required
+    if (!$company && !$cif && !$brand) {
         http_response_code(400);
-        echo json_encode(['error' => 'Company name is required', 'code' => 400]);
+        echo json_encode(['error' => 'At least one of company, cif, or brand is required']);
         exit;
     }
 
+    // Validate confirmation
+    if ($confirmation !== 'CLEAN_COMPANY_JOBS') {
+        http_response_code(400);
+        echo json_encode(['error' => 'Confirmation must be "CLEAN_COMPANY_JOBS"']);
+        exit;
+    }
+
+    // Validate input length
+    if ($company && strlen($company) > 200) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Company name too long (max 200 characters)']);
+        exit;
+    }
+    if ($cif && strlen($cif) > 20) {
+        http_response_code(400);
+        echo json_encode(['error' => 'CIF too long']);
+        exit;
+    }
+    if ($brand && strlen($brand) > 200) {
+        http_response_code(400);
+        echo json_encode(['error' => 'Brand name too long (max 200 characters)']);
+        exit;
+    }
+
+    // Auth: validate X-Api-Key header
+    $apiKey = trim($_SERVER['HTTP_X_API_KEY'] ?? '');
+    if (empty($apiKey)) {
+        http_response_code(401);
+        echo json_encode(['error' => 'Unauthorized - missing X-Api-Key header']);
+        exit;
+    }
+
+    // Determine expected key based on provided fields
+    if ($company && $cif) {
+        $expectedKey = md5($company . $cif);
+        if (!hash_equals($expectedKey, $apiKey)) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized - invalid X-Api-Key']);
+            exit;
+        }
+    } elseif ($company) {
+        $expectedKey = md5($company);
+        if (!hash_equals($expectedKey, $apiKey)) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized - invalid X-Api-Key']);
+            exit;
+        }
+        error_log("CLEANJOBS WARNING: auth by company name only (no CIF) for '$company'");
+    } elseif ($brand) {
+        $expectedKey = md5($brand);
+        if (!hash_equals($expectedKey, $apiKey)) {
+            http_response_code(401);
+            echo json_encode(['error' => 'Unauthorized - invalid X-Api-Key']);
+            exit;
+        }
+        error_log("CLEANJOBS WARNING: auth by brand only for '$brand'");
+    }
+
+    // Build Solr query
     $core = 'job';
     $base = "http://$PROD_SERVER/solr/$core";
 
-    $countUrl = $base . "/select?q=" . rawurlencode('company:"' . $company . '"') . "&wt=json&rows=0";
-    error_log("CLEANJOBS COUNT URL: $countUrl");
+    $queryParts = [];
 
+    if ($cif) {
+        $queryParts[] = 'cif:' . solrEscape($cif);
+    }
+
+    if ($company) {
+        $queryParts[] = 'company:"' . solrEscape($company) . '"';
+    }
+
+    if ($brand) {
+        $companyCore = "http://$PROD_SERVER/solr/company";
+        $brandUrl = $companyCore . "/select?q=" . rawurlencode('brand:"' . solrEscape($brand) . '"') . "&wt=json&rows=100&fl=id,company";
+
+        $brandResponse = fetchJson($brandUrl, $SOLR_USER, $SOLR_PASS, 4);
+        $brandDocs = $brandResponse['response']['docs'] ?? [];
+
+        if (empty($brandDocs)) {
+            http_response_code(404);
+            echo json_encode(['error' => "No companies found for brand '$brand'"]);
+            exit;
+        }
+
+        $cifList = [];
+        foreach ($brandDocs as $doc) {
+            $cifList[] = 'cif:' . solrEscape($doc['id']);
+        }
+
+        if (!empty($queryParts)) {
+            $queryParts[] = '(' . implode(' OR ', $cifList) . ')';
+        } else {
+            $queryParts = [implode(' OR ', $cifList)];
+        }
+    }
+
+    $query = implode(' AND ', $queryParts);
+
+    // Count matching jobs
+    $countUrl = $base . "/select?q=" . rawurlencode($query) . "&wt=json&rows=0";
     $countResponse = fetchJson($countUrl, $SOLR_USER, $SOLR_PASS, 4);
     $jobCount = $countResponse['response']['numFound'] ?? 0;
 
     if ($jobCount === 0) {
         http_response_code(404);
         echo json_encode([
-            'error' => 'Company not found',
-            'message' => "No jobs found for the specified company '$company'",
-            'code' => 404
+            'error' => 'No jobs found',
+            'message' => 'No jobs found matching the given criteria'
         ]);
         exit;
     }
 
+    // Execute delete
     $deleteUrl = $base . "/update?commit=true&wt=json";
-    $deletePayload = json_encode(['delete' => ['query' => 'company:"' . $company . '"']]);
-    error_log("CLEANJOBS DELETE URL: $deleteUrl");
+    $deletePayload = json_encode(['delete' => ['query' => $query]]);
 
-    $deleteResponse = postJson($deleteUrl, $deletePayload, $SOLR_USER, $SOLR_PASS);
+    postJson($deleteUrl, $deletePayload, $SOLR_USER, $SOLR_PASS);
+
+    // Build response
+    $response = [
+        'message' => 'Jobs deleted successfully',
+        'jobCount' => $jobCount
+    ];
+    if ($company) $response['company'] = $company;
+    if ($cif) $response['cif'] = $cif;
+    if ($brand) $response['brand'] = $brand;
+
+    error_log("CLEANJOBS SUCCESS: company=$company cif=$cif brand=$brand jobsDeleted=$jobCount");
 
     http_response_code(200);
-    echo json_encode([
-        'message' => "Jobs for company '$company' deleted successfully",
-        'jobCount' => $jobCount
-    ]);
+    echo json_encode($response);
 
 } catch (Exception $e) {
     error_log("CLEANJOBS FAILED: " . $e->getMessage());

--- a/v1/cleanjobs/index.php
+++ b/v1/cleanjobs/index.php
@@ -1,4 +1,85 @@
 <?php
+
+/**
+ * ============================================================================
+ * DELETE /v1/cleanjobs/ - Company Job Cleanup Endpoint
+ * ============================================================================
+ *
+ * DESCRIPTION:
+ *   This endpoint permanently deletes ALL job records for a specific company
+ *   from the Solr database. Designed for company website owners who want to
+ *   remove their job listings from the peviitor platform.
+ *   WARNING: This action cannot be undone. No recovery possible without backups.
+ *
+ * DEPENDENCIES:
+ *   - Apache Solr server (required, configured via PROD_SERVER in api.env)
+ *   - Solr Basic Authentication (SOLR_USER and SOLR_PASS from api.env)
+ *     All Solr requests use: Authorization: Basic base64(SOLR_USER:SOLR_PASS)
+ *   - 'job' core in Solr (job records deleted from this core)
+ *   - 'company' core in Solr (used for brand lookup only)
+ *
+ * AUTHENTICATION:
+ *   X-Api-Key header computed as md5() of the provided identifiers:
+ *     - company + cif  →  md5(company . cif)  (recommended)
+ *     - company only   →  md5(company)
+ *     - brand only     →  md5(brand)
+ *
+ * REQUIRED HTTP METHOD:
+ *   DELETE (only this method is allowed)
+ *
+ * REQUIRED HEADERS:
+ *   X-Api-Key: <md5 hash of identifiers>
+ *   Content-Type: application/json
+ *
+ * REQUIRED REQUEST BODY:
+ *   {
+ *     "company"?: "NUME SRL",       // company name (optional if cif or brand given)
+ *     "cif"?: "12345678",           // CIF/CUI (optional if company or brand given)
+ *     "brand"?: "ORANGE",           // brand name (optional if company or cif given)
+ *     "confirmation": "CLEAN_COMPANY_JOBS"  // must be exactly this string
+ *   }
+ *   At least one of company, cif, or brand is required.
+ *
+ * IDENTIFICATION LOGIC:
+ *   - cif present: delete jobs where cif matches (precise, unique)
+ *   - company present: delete jobs where company name matches
+ *   - brand present: lookup company core by brand, extract CIFs, then delete jobs by CIF
+ *   - Multiple identifiers can be combined for precision (AND logic)
+ *
+ * SUCCESS RESPONSE (200 OK):
+ *   {
+ *     "message": "Jobs deleted successfully",
+ *     "jobCount": <number>,
+ *     "company"?: "NUME SRL",
+ *     "cif"?: "12345678",
+ *     "brand"?: "ORANGE"
+ *   }
+ *
+ * ERROR RESPONSES:
+ *   400: Bad request (missing fields, invalid confirmation, etc.)
+ *   401: Unauthorized (invalid or missing X-Api-Key)
+ *   404: No jobs found for the given criteria
+ *   405: Method not allowed (only DELETE is allowed)
+ *   503: Service unavailable (Solr server down or misconfiguration)
+ *
+ * EXAMPLE CURL:
+ *   COMPANY="NUME SRL"
+ *   CIF="12345678"
+ *   KEY=$(echo -n "${COMPANY}${CIF}" | md5sum | cut -d' ' -f1)
+ *
+ *   curl -X DELETE \
+ *     -H "X-Api-Key: $KEY" \
+ *     -H "Content-Type: application/json" \
+ *     -d '{
+ *       "company": "'"$COMPANY"'",
+ *       "cif": "'"$CIF"'",
+ *       "confirmation": "CLEAN_COMPANY_JOBS"
+ *     }' \
+ *     https://api.peviitor.ro/v1/cleanjobs/
+ *
+ * ============================================================================
+ */
+
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 


### PR DESCRIPTION
## Changes

### `v1/cleanjobs/index.php`
- **Authentication:** `X-Api-Key: md5(company + cif)` — developerul își calculează singur cheia
- **Body JSON support:** detectează `Content-Type` și parsează JSON sau form-encoded
- **Identificare flexibilă:** `company`, `cif`, `brand` (cel puțin unul obligatoriu)
- **Brand flow:** lookup în company core după brand → extrage CIF-uri → șterge joburile
- **Confirmare:** `confirmation: "CLEAN_COMPANY_JOBS"` obligatoriu
- **Solr injection prevention:** `solrEscape()` pe toate caracterele speciale
- **Input validation:** lungime maximă, string gol
- **Logging:** curat, fără URL-uri Solr interne

### `index.php`
- Documentație completă pentru `DELETE /v1/cleanjobs/` pe api.peviitor.ro (EN + RO)

## Breaking changes
- Endpointul `v1/cleanjobs/` acum cere `X-Api-Key` header și `confirmation" în body