### PR TITLE
fix: accept 7-digit CIFs in company/add endpoint

### DIFF
--- a/v1/firme/company/add/index.php
+++ b/v1/firme/company/add/index.php
@@ -48,7 +48,7 @@ function normalizeToArray($value): array {
 }
 
 function isValidCif(string $cif): bool {
-    return preg_match('/^\d{8}$/', $cif) === 1;
+    return preg_match('/^\d{2,10}$/', $cif) === 1;
 }
 
 function isValidUrl(string $url): bool {
@@ -94,7 +94,7 @@ try {
     if (!isValidCif($id)) {
         http_response_code(400);
         echo json_encode([
-            "error" => "Field 'id' must be an 8-digit CIF/CUI string (e.g. '24415960')",
+            "error" => "Field 'id' must be a valid CIF/CUI string (2-10 digits, e.g. '24415960')",
             "code" => 400
         ]);
         exit;


### PR DESCRIPTION
## Fix

Changes `isValidCif()` regex from `/^\d{8}$/` to `/^\d{2,10}$/` to accept Romanian CIFs of any valid length (2-10 digits). Older companies can have CIFs as short as 4 digits.

Also updated the error message accordingly.

### Changes
- `v1/firme/company/add/index.php` line 51: regex `/^\d{8}$/` -> `/^\d{2,10}$/`
- `v1/firme/company/add/index.php` line 97: error message updated

Closes #1118
