### PR TITLE
fix: null payload in delete endpoint count query

### DIFF
--- a/v1/scraper/jobs/delete/index.php
+++ b/v1/scraper/jobs/delete/index.php
@@ -121,7 +121,7 @@ try {
         'wt'   => 'json'
     ]);
 
-    $countResponse = postJson($selectUrl, null, $SOLR_USER, $SOLR_PASS);
+    $countResponse = postJson($selectUrl, '', $SOLR_USER, $SOLR_PASS);
     $totalCount = $countResponse['response']['numFound'] ?? 0;
 
     if ($totalCount === 0) {


### PR DESCRIPTION
Fixes fatal error in /v1/scraper/jobs/delete/ — postJson() was called with null payload for the Solr count query, violating the string type hint.

Changed null to empty string so Solr uses URL query params instead.