### PR TITLE
fix: use phrase query for URL in scraper jobs delete endpoint

### DIFF
--- a/v1/scraper/jobs/delete/index.php
+++ b/v1/scraper/jobs/delete/index.php
@@ -150,9 +150,9 @@ try {
         $escapedCif = solrEscape($cif);
         $query = "cif:$escapedCif";
     } else {
-        // URL field values are stored as-is; escape for Solr query syntax
-        $escapedUrl = solrEscape($data['url']);
-        $query = "url:$escapedUrl";
+        // Use phrase query for URLs to avoid escaping special chars like / and -
+        $escapedUrl = str_replace(['\\', '"'], ['\\\\', '\\"'], $data['url']);
+        $query = 'url:"' . $escapedUrl . '"';
     }
 
     // --- 3. Count matching jobs first (GET to /select with URL params) ---


### PR DESCRIPTION
## Problem
The DELETE /v1/scraper/jobs/delete/ endpoint fails with 503 when deleting by URL. solrEscape() over-escapes URL chars (/, -, :) causing Solr to reject with 400.

## Fix
Use phrase query (url:"...") for URL values instead of solrEscape(). Only \ and " are escaped. CIF path unchanged (safe since CIF is digits only).

Fixes #1125