### PR TITLE
fix: correct loadEnv path in v1/firme sub-endpoints

### DIFF
--- a/v1/firme/brand/add/index.php
+++ b/v1/firme/brand/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/brand/delete/index.php
+++ b/v1/firme/brand/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/brand/index.php
+++ b/v1/firme/brand/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/company/delete/index.php
+++ b/v1/firme/company/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/email/add/index.php
+++ b/v1/firme/email/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/email/delete/index.php
+++ b/v1/firme/email/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/email/index.php
+++ b/v1/firme/email/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/logo/add/index.php
+++ b/v1/firme/logo/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/logo/delete/index.php
+++ b/v1/firme/logo/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/logo/index.php
+++ b/v1/firme/logo/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/phone/add/index.php
+++ b/v1/firme/phone/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/phone/delete/index.php
+++ b/v1/firme/phone/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/phone/index.php
+++ b/v1/firme/phone/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/scraper/add/index.php
+++ b/v1/firme/scraper/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/scraper/delete/index.php
+++ b/v1/firme/scraper/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/scraper/index.php
+++ b/v1/firme/scraper/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/website/add/index.php
+++ b/v1/firme/website/add/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/website/delete/index.php
+++ b/v1/firme/website/delete/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../../api.env');
+require_once __DIR__ . '/../../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');

--- a/v1/firme/website/index.php
+++ b/v1/firme/website/index.php
@@ -2,8 +2,8 @@
 header("Access-Control-Allow-Origin: *");
 header("Content-Type: application/json; charset=UTF-8");
 
-require_once __DIR__ . '/../../util/loadEnv.php';
-loadEnv(__DIR__ . '/../../api.env');
+require_once __DIR__ . '/../../../util/loadEnv.php';
+loadEnv(__DIR__ . '/../../../api.env');
 
 $SOLR_SERVER = trim(getenv('SOLR_SERVER') ?: '');
 $PROTOCOL = trim(getenv('PROTOCOL') ?: '');


### PR DESCRIPTION
Fixes #1129

## Problem
The `v1/firme/*` endpoints crash with `loadEnv.php missing` fatal errors because the `require_once`/`loadEnv` relative paths are off by one `..` level, so `util/loadEnv.php` and `api.env` cannot be resolved from the endpoint directories.

## Change
Correct the relative path in 19 endpoints:
- `v1/firme/{brand,email,logo,phone,scraper,website}/index.php`: `'../../'` → `'../../../'`
- `v1/firme/{brand,company,email,logo,phone,scraper,website}/{add,delete}/index.php`: `'../../../'` → `'../../../../'`

`v1/firme/company/add/` already had the correct 4-level path on master; its sibling endpoints did not.